### PR TITLE
Option to sort photos into year/months directories.

### DIFF
--- a/gimme_iphotos/__init__.py
+++ b/gimme_iphotos/__init__.py
@@ -77,6 +77,12 @@ def get_cli_args() -> argparse.Namespace:
         dest="group_by_year_month",
         help="Group the photos into year and month directories.",
     )
+    parser.add_argument(
+        "--zero-pad",
+        action="store_true",
+        dest="group_by_year_month_zero_pad",
+        help="Zero pad months when grouping photos.",
+    )
 
     return parser.parse_args()
 

--- a/gimme_iphotos/__init__.py
+++ b/gimme_iphotos/__init__.py
@@ -71,11 +71,11 @@ def get_cli_args() -> argparse.Namespace:
         help="Max number of concurrent downloads. Increase this number if bandwidth is not fully utilized. Default: 3",
     )
     parser.add_argument(
-        "-s",
-        "--sort",
+        "-g",
+        "--group",
         action="store_true",
-        dest="directory_sort",
-        help="Sort the photos into year and month directories.",
+        dest="group_by_year_month",
+        help="Group the photos into year and month directories.",
     )
 
     return parser.parse_args()

--- a/gimme_iphotos/__init__.py
+++ b/gimme_iphotos/__init__.py
@@ -70,6 +70,13 @@ def get_cli_args() -> argparse.Namespace:
         type=int,
         help="Max number of concurrent downloads. Increase this number if bandwidth is not fully utilized. Default: 3",
     )
+    parser.add_argument(
+        "-s",
+        "--sort",
+        action="store_true",
+        dest="directory_sort",
+        help="Sort the photos into year and month directories.",
+    )
 
     return parser.parse_args()
 

--- a/gimme_iphotos/downloader.py
+++ b/gimme_iphotos/downloader.py
@@ -25,7 +25,7 @@ class DownloaderApp:
         "destination": None,
         "overwrite": False,
         "remove": False,
-        "directory_sort": False,
+        "group_by_year_month": False,
         "parallel": 3,
     }
 
@@ -107,7 +107,7 @@ class DownloaderApp:
         api = self.connect_to_icloud(config)
 
         icloud_photos = self.download_photos(
-            api, config["destination"], config["overwrite"], config["parallel"], config["directory_sort"]
+            api, config["destination"], config["overwrite"], config["parallel"], config["group_by_year_month"]
         )
 
         if config["remove"]:
@@ -167,7 +167,7 @@ class DownloaderApp:
         destination: str,
         overwrite_existing: bool,
         parallel: int = 3,
-        directory_sort: bool = False,
+        group_by_year_month: bool = False,
     ) -> Set[str]:
         print(
             "Downloading all photos into '{}' while {} existing…".format(
@@ -193,7 +193,7 @@ class DownloaderApp:
                 downloads = []
                 for photo in collection:
                     total_count += 1
-                    if directory_sort:
+                    if group_by_year_month:
                         if photo.asset_date:
                             destination_directory = os.path.join(destination, str(photo.asset_date.year), str(photo.asset_date.month))
                         else:

--- a/gimme_iphotos/downloader.py
+++ b/gimme_iphotos/downloader.py
@@ -26,6 +26,7 @@ class DownloaderApp:
         "overwrite": False,
         "remove": False,
         "group_by_year_month": False,
+        "group_by_year_month_zero_pad": False,
         "parallel": 3,
     }
 
@@ -166,7 +167,6 @@ class DownloaderApp:
         api: PyiCloudService,
         destination: str,
         overwrite_existing: bool,
-        group_by_year_month: bool,
         parallel: int = 3,
     ) -> Set[str]:
         print(
@@ -193,32 +193,7 @@ class DownloaderApp:
                 downloads = []
                 for photo in collection:
                     total_count += 1
-                    if group_by_year_month:
-                        if photo.asset_date:
-                            destination_directory = os.path.join(destination, str(photo.asset_date.year), str(photo.asset_date.month))
-                        else:
-                            destination_directory = os.path.join(destination, "NO_DATE")
-                        filename = os.path.join(destination_directory, photo.filename)
-                    else:
-                        filename = os.path.join(destination, photo.filename)
-
-                    if filename in icloud_photos:
-                        """If the filename has already been encountered try to
-                        rename it like so:
-                            img.jpg -> img 2.jpg -> img 3.jpg ...
-                        Photos are ordered by date added so this works across runs.
-                        Maximum rename attempts is arbitrarily set at 100.
-                        """
-                        root, ext = os.path.splitext(filename)
-                        for i in range(2, 102):
-                            new_filename = f"{root} {i}{ext}"
-                            if new_filename not in icloud_photos:
-                                filename = new_filename
-                                break
-                        else:
-                            self.logger.critical("Exceeded 100 rename attempts.")
-                            break
-
+                    filename = self.name_photo(photo, icloud_photos, destination)
                     icloud_photos.add(filename)
                     if os.path.isfile(filename):
                         if not overwrite_existing:
@@ -250,6 +225,39 @@ class DownloaderApp:
         self.logger.debug("icloud_photos: %s", icloud_photos)
 
         return icloud_photos
+
+    def name_photo(self, photo, icloud_photos: set, destination: str) -> None:
+        if self.config["group_by_year_month_zero_pad"]:
+            month_format = "%02d"
+        else:
+            month_format = "%d"
+
+        if self.config["group_by_year_month"]:
+            if photo.asset_date:
+                destination_directory = os.path.join(destination,
+                                                     "%04d" % photo.asset_date.year,
+                                                     month_format % photo.asset_date.month)
+            else:
+                destination_directory = os.path.join(destination, "NO_DATE")
+            filename = os.path.join(destination_directory, photo.filename)
+        else:
+            filename = os.path.join(destination, photo.filename)
+
+        if filename in icloud_photos:
+            """If the filename has already been encountered try to
+            rename it like so:
+                img.jpg -> img 2.jpg -> img 3.jpg ...
+            Photos are ordered by date added so this works across runs.
+            Maximum rename attempts is arbitrarily set at 100.
+            """
+            root, ext = os.path.splitext(filename)
+            for i in range(2, 102):
+                new_filename = f"{root} {i}{ext}"
+                if new_filename not in icloud_photos:
+                    filename = new_filename
+                    break
+            else:
+                raise(Exception(f"Exceeded 100 files with the name {filename}."))
 
     def download_photo(self, photo, filename: str, temp_file_dir: str) -> None:
         download = photo.download()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,7 @@ gimme-iphotos = 'gimme_iphotos:main'
 
 [tool.poetry.dependencies]
 python = "^3.6"
-# pyicloud = "^0.9.6"
-# Required fix is not yet released (https://github.com/picklepete/pyicloud/pull/300/)
-pyicloud-z = "^0.9.7-beta.2"
+pyicloud = "^0.10.2"
 tqdm = "^4.45.0"
 colorama = "^0.4.3"
 


### PR DESCRIPTION
Pretty simple, creates year/month directories based on the photo's asset date and puts the photo in them. I'm not sure what's a good name for this feature directory sort sounds a bit weird to me.

Also added handling for files with the same name -- if there's already a `test.jpg` it tries `test 2.jpg` and so on in the style of the Mac (there may be preferable ways).

Here's an example screenshot (both of the pictures were named `test_img.jpg`)
![Screen Shot 2021-10-28 at 16 37 33](https://user-images.githubusercontent.com/3087025/139267206-f9de6f25-d55f-41d4-9094-4daba4208c03.png)
